### PR TITLE
Safari Compatibility

### DIFF
--- a/addon/mixins/stagger-set.js
+++ b/addon/mixins/stagger-set.js
@@ -431,11 +431,14 @@ export default Mixin.create({
     const currentAnimationDuration = `${this.get('currentAnimationDuration')}ms`;
     const currentAnimationTimingFunction = this.get('currentAnimationTimingFunction');
 
+    // inDelay / outDelay
+    const currentDelay = this.get('showItems') ? this.get('inDelay') : this.get('outDelay');    
+    
     const animationPrefix = this.get('_animationPrefix');
     const propertyPrefix = animationPrefix ? `${animationPrefix}A` : 'a';
-
+    
     this._listItemElems.forEach((listItemElem, idx) => {
-      listItemElem.style[`${propertyPrefix}nimationDelay`] = `${currentStaggerInterval * (idx + 1)}ms`;
+      listItemElem.style[`${propertyPrefix}nimationDelay`] = `${(currentStaggerInterval * (idx + 1)) + currentDelay}ms`;
       listItemElem.style[`${propertyPrefix}nimationTimingFunction`] = currentAnimationTimingFunction;
       listItemElem.style[`${propertyPrefix}nimationDuration`] = currentAnimationDuration;
       listItemElem.style[`${propertyPrefix}nimationName`] = currentAnimationName;

--- a/app/styles/ember-stagger-swagger.css
+++ b/app/styles/ember-stagger-swagger.css
@@ -25,6 +25,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -36,6 +37,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
@@ -49,6 +51,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -60,6 +63,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -73,6 +77,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -84,6 +89,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
@@ -97,6 +103,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -108,6 +115,7 @@
   }
   100% {
     opacity: 1;
+    visibility: visible;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
@@ -124,6 +132,8 @@
     transform: translate3d(-100%, 0, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -134,6 +144,8 @@
     -webkit-transform: translate3d(-100%, 0, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
@@ -146,6 +158,8 @@
     transform: translate3d(100%, 0, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -156,6 +170,8 @@
     -webkit-transform: translate3d(100%, 0, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
@@ -168,6 +184,8 @@
     transform: translate3d(0, -100%, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -178,6 +196,8 @@
     -webkit-transform: translate3d(0, -100%, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
@@ -190,6 +210,8 @@
     transform: translate3d(0, 100%, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     transform: translate3d(0, 0, 0);
   }
 }
@@ -200,6 +222,8 @@
     -webkit-transform: translate3d(0, 100%, 0);
   }
   100% {
+    opacity: 1;
+    visibility: visible;
     -webkit-transform: translate3d(0, 0, 0);
   }
 }
@@ -215,6 +239,7 @@
     opacity: 0;
   }
   100% {
+    visibility: visible;
     opacity: 1;
   }
 }
@@ -224,6 +249,7 @@
     opacity: 0;
   }
   100% {
+    visibility: visible;
     opacity: 1;
   }
 }
@@ -240,6 +266,7 @@
     transform: scale(0);
   }
   100% {
+    visibility: visible;
     opacity: 1;
     transform: scale(1);
   }
@@ -251,6 +278,7 @@
     -webkit-transform: scale(0);
   }
   100% {
+    visibility: visible;
     opacity: 1;
     -webkit-transform: scale(1);
   }


### PR DESCRIPTION
Addresses #7 issue with first load on Safari and iOS webkit-based browsers.

Items were not remaining visible after load on Safari on OSX. This was apparent on the Stagger Swagger demo:

http://www.sipple.io/ember-stagger-swagger-demo/#/homepage

This patch adds visibility: visible to the end of all default keyframe animations and appears to correct the problem. I suspect the inverse is true (visibility: hidden needs to be added to the endframe of all out animations) but did not test for that as my app did not need it.
