### PR TITLE
Support for inDelay / outDelay

### DIFF
--- a/addon/mixins/stagger-set.js
+++ b/addon/mixins/stagger-set.js
@@ -431,11 +431,14 @@ export default Mixin.create({
     const currentAnimationDuration = `${this.get('currentAnimationDuration')}ms`;
     const currentAnimationTimingFunction = this.get('currentAnimationTimingFunction');
 
+    // inDelay / outDelay
+    const currentDelay = this.get('showItems') ? this.get('inDelay') : this.get('outDelay');    
+    
     const animationPrefix = this.get('_animationPrefix');
     const propertyPrefix = animationPrefix ? `${animationPrefix}A` : 'a';
-
+    
     this._listItemElems.forEach((listItemElem, idx) => {
-      listItemElem.style[`${propertyPrefix}nimationDelay`] = `${currentStaggerInterval * (idx + 1)}ms`;
+      listItemElem.style[`${propertyPrefix}nimationDelay`] = `${(currentStaggerInterval * (idx + 1)) + currentDelay}ms`;    
       listItemElem.style[`${propertyPrefix}nimationTimingFunction`] = currentAnimationTimingFunction;
       listItemElem.style[`${propertyPrefix}nimationDuration`] = currentAnimationDuration;
       listItemElem.style[`${propertyPrefix}nimationName`] = currentAnimationName;


### PR DESCRIPTION
Maybe I was missing something, but I did not see support for inDelay / outDelay.

This patch modifies _setAnimationValuesForItems to add inDelay / outDelay to the animation-delay value in each element in the swagger set. When _listItemElems are iterated, animation-delay receives the combined value of the currentDelay + the in / outDelay. 
