### PR TITLE
Use relative styles path

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = {
 
     const Funnel = require('broccoli-funnel');
     const mergeTrees = require('broccoli-merge-trees');
-    const stylesPath = path.join(this.project.nodeModulesPath, this.name, 'app', 'styles');
+    const stylesPath = path.join(__dirname, 'app', 'styles');
 
     const cssTree = new Funnel(stylesPath, { include: [MATCH_CSS] });
 


### PR DESCRIPTION
While attempting to use this addon, I ran into an error where the stylesPath was being set to the consuming app's node_modules directory. I propose using the relative `__dirname` instead.